### PR TITLE
Fix Fresnel phase computation and update test script

### DIFF
--- a/core/propagation.py
+++ b/core/propagation.py
@@ -75,7 +75,8 @@ class OpticalPropagation:
         field_prop_fft = field_fft * H_transfer.unsqueeze(0)
         field_prop = torch.fft.ifft2(field_prop_fft)
         
-        field_prop = field_prop * torch.exp(1j * k * distance)
+        phase = torch.tensor(k * distance, dtype=field_prop.dtype, device=device)
+        field_prop = field_prop * torch.exp(1j * phase)
         
         return field_prop.squeeze(0) if squeeze_batch else field_prop
     

--- a/test_working.py
+++ b/test_working.py
@@ -50,7 +50,7 @@ except Exception as e:
 try:
     from core.metrics import CompressionMetrics
     metrics = CompressionMetrics()
-    psnr = metrics.psnr(test_image[0], reconstructed[0,0])
+    psnr = metrics.psnr(test_image[0], reconstructed[0])
     print(f"✓ Metrics successful! PSNR: {psnr:.2f} dB")
 except Exception as e:
     print(f"✗ Metrics error: {e}")
@@ -63,11 +63,11 @@ try:
     axes[0].set_title('Original')
     axes[0].axis('off')
     
-    axes[1].imshow(output['intensity_sensor'][0].numpy(), cmap='gray')
+    axes[1].imshow(output['intensity_sensor'][0].detach().numpy(), cmap='gray')
     axes[1].set_title('Sensor Output')
     axes[1].axis('off')
     
-    axes[2].imshow(reconstructed[0,0].detach().numpy(), cmap='gray')
+    axes[2].imshow(reconstructed[0].detach().numpy(), cmap='gray')
     axes[2].set_title('Reconstructed')
     axes[2].axis('off')
     


### PR DESCRIPTION
## Summary
- Ensure Fresnel propagation multiplies a tensor-based phase factor instead of a Python complex number
- Adjust test script to detach tensors and use correct shapes for PSNR and visualization

## Testing
- `python test_working.py`

------
https://chatgpt.com/codex/tasks/task_e_68984752fd7c83268381a3dffa71cf7c