### PR TITLE
Add recurrent waveguide element

### DIFF
--- a/elements/__init__.py
+++ b/elements/__init__.py
@@ -2,5 +2,6 @@ from .base import OpticalElement
 from .phase_mask import PhaseMask
 from .coded_aperture import CodedAperture
 from .lens_array import LensArray
+from .waveguide import Waveguide
 
-__all__ = ['OpticalElement', 'PhaseMask', 'CodedAperture', 'LensArray']
+__all__ = ['OpticalElement', 'PhaseMask', 'CodedAperture', 'LensArray', 'Waveguide']

--- a/elements/waveguide.py
+++ b/elements/waveguide.py
@@ -1,0 +1,76 @@
+import torch
+from .base import OpticalElement
+from core.propagation import OpticalPropagation
+
+
+class Waveguide(OpticalElement):
+    """Simple waveguide element with recurrent reflection.
+
+    Parameters
+    ----------
+    resolution : tuple
+        Spatial resolution (H, W).
+    pixel_pitch : float
+        Pixel pitch in meters.
+    wavelength : float
+        Operating wavelength in meters.
+    transmission : float
+        Fraction of the field that directly exits without entering the
+        waveguide. Corresponds to :math:`p_1` in the user description.
+    coupling : float
+        Fraction of the waveguided field that exits the guide on each
+        round trip. This acts like :math:`p_2, p_3, ...` when assumed
+        constant.
+    reflection : float
+        Amplitude reflection coefficient at the distant surface.
+    waveguide_length : float
+        Physical length of the guide (distance between reflective
+        surfaces) in meters. Each round trip propagates this distance
+        twice (forth and back).
+    max_roundtrips : int
+        Maximum number of internal reflections to simulate.
+    """
+
+    def __init__(
+        self,
+        resolution,
+        pixel_pitch,
+        wavelength,
+        transmission=0.5,
+        coupling=0.5,
+        reflection=0.9,
+        waveguide_length=1e-3,
+        max_roundtrips=3,
+        name=None,
+    ):
+        self.transmission = transmission
+        self.coupling = coupling
+        self.reflection = reflection
+        self.waveguide_length = waveguide_length
+        self.max_roundtrips = max_roundtrips
+        super().__init__(resolution, pixel_pitch, wavelength, name)
+
+    def _init_parameters(self):
+        self.propagator = OpticalPropagation()
+
+    def forward(self, field):
+        field = self.ensure_complex(field)
+        output = self.transmission * field
+        wg_field = (1 - self.transmission) * field
+        for _ in range(self.max_roundtrips):
+            if torch.abs(wg_field).max() < 1e-8:
+                break
+            wg_field = self.propagator.propagate(
+                wg_field, self.waveguide_length, self.wavelength, self.pixel_pitch
+            )
+            wg_field = self.reflection * wg_field
+            wg_field = self.propagator.propagate(
+                wg_field, self.waveguide_length, self.wavelength, self.pixel_pitch
+            )
+            leaked = self.coupling * wg_field
+            output = output + leaked
+            wg_field = (1 - self.coupling) * wg_field
+        return output
+
+    def visualize(self):
+        return {}

--- a/system/builder.py
+++ b/system/builder.py
@@ -50,6 +50,25 @@ class SystemBuilder:
         self.elements.append(element)
         self.element_positions.append(position)
         return self
+
+    def add_waveguide(self, position=0.0, transmission=0.5, coupling=0.5,
+                      reflection=0.9, waveguide_length=1e-3,
+                      max_roundtrips=3, **kwargs):
+        from elements.waveguide import Waveguide
+        element = Waveguide(
+            resolution=self.config.sensor_resolution,
+            pixel_pitch=self.config.pixel_pitch,
+            wavelength=self.config.wavelength,
+            transmission=transmission,
+            coupling=coupling,
+            reflection=reflection,
+            waveguide_length=waveguide_length,
+            max_roundtrips=max_roundtrips,
+            **kwargs
+        )
+        self.elements.append(element)
+        self.element_positions.append(position)
+        return self
     
     def build(self):
         if len(self.elements) == 0:

--- a/tests/test_waveguide.py
+++ b/tests/test_waveguide.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import torch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from elements.waveguide import Waveguide
+
+
+def test_waveguide_pass_through():
+    wg = Waveguide((8, 8), 1e-6, 500e-9, transmission=1.0, coupling=0.0,
+                   reflection=0.0, max_roundtrips=0)
+    field = torch.ones(1, 8, 8, dtype=torch.complex64)
+    out = wg(field)
+    assert torch.allclose(out, field)
+
+
+def test_waveguide_single_roundtrip():
+    wg = Waveguide((8, 8), 1e-6, 500e-9, transmission=0.0, coupling=1.0,
+                   reflection=1.0, waveguide_length=0.0, max_roundtrips=1)
+    field = torch.ones(1, 8, 8, dtype=torch.complex64)
+    out = wg(field)
+    assert torch.allclose(out, field)


### PR DESCRIPTION
## Summary
- implement Waveguide optical element with recursive reflections and leakage
- expose Waveguide in elements module and SystemBuilder
- add tests covering pass-through and single round-trip behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689850c11e388326a99e226475d54210