### PR TITLE
Add Fraunhofer propagation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ python examples/quick_demo.py
 
 ## Features
 
-- Physical optics simulation with multiple propagation methods
+- Physical optics simulation with multiple propagation methods (angular spectrum, Fresnel, Fraunhofer)
 - Modular optical elements (phase masks, coded apertures, lens arrays)
 - End-to-end optimization with learnable elements
 - Neural network decoders for reconstruction


### PR DESCRIPTION
## Summary
- add Fraunhofer propagation implementation using FFT
- allow propagate to dispatch Fraunhofer method
- document supported propagation methods

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68984df57aa483268c494afb2683f401